### PR TITLE
Fix problem order initialization

### DIFF
--- a/src/main/java/com/aloc/aloc/course/service/UserCourseService.java
+++ b/src/main/java/com/aloc/aloc/course/service/UserCourseService.java
@@ -44,15 +44,18 @@ public class UserCourseService {
 
     List<Problem> problems =
         course.getCourseProblemList().stream().map(CourseProblem::getProblem).toList();
+
+    int order = 1;
     for (Problem problem : problems) {
       UserCourseProblem userCourseProblem =
-          userCourseProblemService.createUserCourseProblem(userCourse, problem);
+          userCourseProblemService.createUserCourseProblem(userCourse, problem, order);
 
-      if (userCourse.getUserCourseProblemList().isEmpty()) {
+      if (order == 1) {
         userCourseProblem.updateUserCourseProblemStatus(UserCourseProblemStatus.UNSOLVED);
         userCourseProblemService.saveUserCourserProblem(userCourseProblem);
       }
       userCourse.addUserCourseProblem(userCourseProblem);
+      order++;
     }
     return userCourseRepository.save(userCourse);
   }

--- a/src/main/java/com/aloc/aloc/problem/service/UserCourseProblemService.java
+++ b/src/main/java/com/aloc/aloc/problem/service/UserCourseProblemService.java
@@ -52,8 +52,7 @@ public class UserCourseProblemService {
 
   public UserCourseProblem createUserCourseProblem(
       UserCourse userCourse, Problem problem, int problemOrder) {
-    UserCourseProblem userCourseProblem = UserCourseProblem.of(userCourse, problem);
-    userCourseProblem.setProblemOrder(problemOrder);
+    UserCourseProblem userCourseProblem = UserCourseProblem.of(userCourse, problem, problemOrder);
     return userCourseProblemRepository.save(userCourseProblem);
   }
 

--- a/src/main/java/com/aloc/aloc/problem/service/UserCourseProblemService.java
+++ b/src/main/java/com/aloc/aloc/problem/service/UserCourseProblemService.java
@@ -50,8 +50,10 @@ public class UserCourseProblemService {
         .toList();
   }
 
-  public UserCourseProblem createUserCourseProblem(UserCourse userCourse, Problem problem) {
+  public UserCourseProblem createUserCourseProblem(
+      UserCourse userCourse, Problem problem, int problemOrder) {
     UserCourseProblem userCourseProblem = UserCourseProblem.of(userCourse, problem);
+    userCourseProblem.setProblemOrder(problemOrder);
     return userCourseProblemRepository.save(userCourseProblem);
   }
 

--- a/src/main/java/com/aloc/aloc/user/service/UserSortingService.java
+++ b/src/main/java/com/aloc/aloc/user/service/UserSortingService.java
@@ -26,7 +26,6 @@ public class UserSortingService {
   }
 
   private record Pair<T extends Comparable<T>, U extends Comparable<U>>(T first, U second)
-
       implements Comparable<Pair<T, U>> {
 
     @Override

--- a/src/main/java/com/aloc/aloc/usercourse/entity/UserCourseProblem.java
+++ b/src/main/java/com/aloc/aloc/usercourse/entity/UserCourseProblem.java
@@ -9,11 +9,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -38,11 +36,12 @@ public class UserCourseProblem extends AuditingTimeEntity {
   @Column(name = "problem_order")
   private Integer problemOrder;
 
-  public static UserCourseProblem of(UserCourse userCourse, Problem problem) {
+  public static UserCourseProblem of(UserCourse userCourse, Problem problem, int problemOrder) {
     return UserCourseProblem.builder()
         .problem(problem)
         .userCourse(userCourse)
         .userCourseProblemStatus(UserCourseProblemStatus.HIDDEN)
+        .problemOrder(problemOrder)
         .build();
   }
 

--- a/src/main/java/com/aloc/aloc/usercourse/entity/UserCourseProblem.java
+++ b/src/main/java/com/aloc/aloc/usercourse/entity/UserCourseProblem.java
@@ -9,9 +9,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder


### PR DESCRIPTION
## Summary
- ensure `UserCourseProblem` exposes a setter
- set problem order when creating user course problems
- store the order in `UserCourseProblemService`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6840ff1958ac8320836ea5c9b9075261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자 코스 문제에 문제 순서(order)가 명시적으로 부여되어 관리됩니다.

- **버그 수정**
  - 첫 번째 문제의 상태가 올바르게 UNSOLVED로 설정됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->