### PR TITLE
218 feat algorithm 도메인 테스트 코드

### DIFF
--- a/src/test/java/com/aloc/aloc/algorithm/service/AlgorithmServiceTest.java
+++ b/src/test/java/com/aloc/aloc/algorithm/service/AlgorithmServiceTest.java
@@ -1,186 +1,168 @@
 package com.aloc.aloc.algorithm.service;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.aloc.aloc.algorithm.dto.response.AlgorithmResponseDto;
 import com.aloc.aloc.algorithm.entity.Algorithm;
 import com.aloc.aloc.algorithm.repository.AlgorithmRepository;
-
 import java.util.List;
-import java.util.Optional;
 import java.util.NoSuchElementException;
-
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.any;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-
-//테스트 함수 목록
-//[getAlgorithmsByIds] 메서드 테스트
-//[getAlgorithmsByIds] 없는 알고리즘 아이디 조회 테스트
-//[getOrCreateAlgorithm] 기존 알고리즘 조회 테스트
-//[getOrCreateAlgorithm] 새 알고리즘 생성 테스트
-//[getAlgorithms] 정상 케이스 테스트
-//[getAlgorithms] 빈 목록 케이스 테스트
+// 테스트 함수 목록
+// [getAlgorithmsByIds] 메서드 테스트
+// [getAlgorithmsByIds] 없는 알고리즘 아이디 조회 테스트
+// [getOrCreateAlgorithm] 기존 알고리즘 조회 테스트
+// [getOrCreateAlgorithm] 새 알고리즘 생성 테스트
+// [getAlgorithms] 정상 케이스 테스트
+// [getAlgorithms] 빈 목록 케이스 테스트
 
 @ExtendWith(MockitoExtension.class)
 public class AlgorithmServiceTest {
 
-    // Algorithm Repository를 모방한 가짜 객체 만들기
-    @Mock
-    private AlgorithmRepository algorithmRepository;
+  // Algorithm Repository를 모방한 가짜 객체 만들기
+  @Mock private AlgorithmRepository algorithmRepository;
 
-    // 가짜 객체를 사용하는 AlgorithmService 객체 만들기
-    @InjectMocks
-    private AlgorithmService algorithmService;
+  // 가짜 객체를 사용하는 AlgorithmService 객체 만들기
+  @InjectMocks private AlgorithmService algorithmService;
 
-    //[getAlgorithmsByIds] 메서드 테스트
-    @Test
-    void getAlgorithmsByIds_normalCase() {
-        //given
-        //id 1인 객체를 생성
-        Integer algorithmId = 1;
-        Algorithm algorithm = Algorithm.builder()
-            .algorithmId(algorithmId)
-            .koreanName("테스트")
-            .englishName("test")
-            .build();
-        //algorithmRepository에서 algorithmId 1인 객체를 조회하면 algorithm 객체를 반환
-        given(algorithmRepository.findByAlgorithmId(algorithmId)).willReturn(Optional.of(algorithm));
-    
-        //when
-        //algorithmId를 List.of(algorithmId)로 넘겨서 조회하고 반환된 객체를 List<Algorithm> result에 저장
-        List<Algorithm> result = algorithmService.getAlgorithmsByIds(List.of(algorithmId));
+  // [getAlgorithmsByIds] 메서드 테스트
+  @Test
+  void getAlgorithmsByIdsNormalCase() {
+    // given
+    // id 1인 객체를 생성
+    Integer algorithmId = 1;
+    Algorithm algorithm =
+        Algorithm.builder().algorithmId(algorithmId).koreanName("테스트").englishName("test").build();
+    // algorithmRepository에서 algorithmId 1인 객체를 조회하면 algorithm 객체를 반환
+    given(algorithmRepository.findByAlgorithmId(algorithmId)).willReturn(Optional.of(algorithm));
 
-        //then
-        //result의 크기가 1이고, 첫 번째 요소의 algorithmId가 1인지 확인
-        assertThat(result).containsExactly(algorithm);
-    }
+    // when
+    // algorithmId를 List.of(algorithmId)로 넘겨서 조회하고 반환된 객체를 List<Algorithm> result에 저장
+    List<Algorithm> result = algorithmService.getAlgorithmsByIds(List.of(algorithmId));
 
-    //[getAlgorithmById] 없는 알고리즘 아이디 조회 테스트
-    @Test
-    void getAlgorithmsById_NotFound() {
-        //given
-        //mock에서는 존재하지 않는 아이디를 조회하면 Optional.empty()를 반환
-        Integer nonExistentId = 999;
-        given(algorithmRepository.findByAlgorithmId(nonExistentId)).willReturn(Optional.empty());
+    // then
+    // result의 크기가 1이고, 첫 번째 요소의 algorithmId가 1인지 확인
+    assertThat(result).containsExactly(algorithm);
+  }
 
-        //when&then
-        assertThatThrownBy(() -> algorithmService.getAlgorithmsByIds(List.of(nonExistentId)))
-            //NoSuchElementException 예외가 발생하고, 메시지에 "존재하지 않은 알고리즘 아이디가 포함되어 있습니다."가 포함되어 있는지 확인
-            .isInstanceOf(NoSuchElementException.class)
-            .hasMessageContaining("존재하지 않은 알고리즘 아이디가 포함되어 있습니다.");
-    }
+  // [getAlgorithmById] 없는 알고리즘 아이디 조회 테스트
+  @Test
+  void getAlgorithmsByIdNotFound() {
+    // given
+    // mock에서는 존재하지 않는 아이디를 조회하면 Optional.empty()를 반환
+    Integer nonExistentId = 999;
+    given(algorithmRepository.findByAlgorithmId(nonExistentId)).willReturn(Optional.empty());
 
-    //[getOrCreateAlgorithm] 기존 알고리즘 조회 테스트
-    @Test
-    void getOrCreateAlgorithm_existingAlgorithm() {
-        // given
-        Integer algorithmId = 1;
-        String koreanName = "정렬";
-        String englishName = "Sort";
-        
-        Algorithm existingAlgorithm = Algorithm.builder()
+    // when&then
+    assertThatThrownBy(() -> algorithmService.getAlgorithmsByIds(List.of(nonExistentId)))
+        // NoSuchElementException 예외가 발생하고, 메시지에 "존재하지 않은 알고리즘 아이디가 포함되어 있습니다."가 포함되어 있는지 확인
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessageContaining("존재하지 않은 알고리즘 아이디가 포함되어 있습니다.");
+  }
+
+  // [getOrCreateAlgorithm] 기존 알고리즘 조회 테스트
+  @Test
+  void getOrCreateAlgorithmExistingAlgorithm() {
+    // given
+    Integer algorithmId = 1;
+    String koreanName = "정렬";
+    String englishName = "Sort";
+
+    Algorithm existingAlgorithm =
+        Algorithm.builder()
             .algorithmId(algorithmId)
             .koreanName("기존 한글명")
             .englishName("Existing English Name")
             .build();
-        
-        given(algorithmRepository.findByAlgorithmId(algorithmId))
-            .willReturn(Optional.of(existingAlgorithm));
 
-        // when
-        Algorithm result = algorithmService.getOrCreateAlgorithm(algorithmId, koreanName, englishName);
+    given(algorithmRepository.findByAlgorithmId(algorithmId))
+        .willReturn(Optional.of(existingAlgorithm));
 
-        // then
-        assertThat(result).isEqualTo(existingAlgorithm);
-        verify(algorithmRepository, never()).save(any(Algorithm.class)); // save는 호출되지 않음
-    }
+    // when
+    Algorithm result = algorithmService.getOrCreateAlgorithm(algorithmId, koreanName, englishName);
 
+    // then
+    assertThat(result).isEqualTo(existingAlgorithm);
+    verify(algorithmRepository, never()).save(any(Algorithm.class)); // save는 호출되지 않음
+  }
 
-    //[getOrCreateAlgorithm] 새 알고리즘 생성 테스트
-    @Test
-    void getOrCreateAlgorithm_newAlgorithm() {
-        // given
-        Integer algorithmId = 2;
-        String koreanName = "그래프";
-        String englishName = "Graph";
-        
-        Algorithm newAlgorithm = Algorithm.builder()
+  // [getOrCreateAlgorithm] 새 알고리즘 생성 테스트
+  @Test
+  void getOrCreateAlgorithmNewAlgorithm() {
+    // given
+    Integer algorithmId = 2;
+    String koreanName = "그래프";
+    String englishName = "Graph";
+
+    Algorithm newAlgorithm =
+        Algorithm.builder()
             .algorithmId(algorithmId)
             .koreanName(koreanName)
             .englishName(englishName)
             .build();
-        //algorithmRepository에서 algorithmId 2인 객체를 조회하면 Optional.empty()를 반환
-        given(algorithmRepository.findByAlgorithmId(algorithmId))
-            .willReturn(Optional.empty());
-        //algorithmRepository에서 save 메서드를 호출하면 newAlgorithm 객체를 반환
-        given(algorithmRepository.save(any(Algorithm.class)))
-            .willReturn(newAlgorithm);
+    // algorithmRepository에서 algorithmId 2인 객체를 조회하면 Optional.empty()를 반환
+    given(algorithmRepository.findByAlgorithmId(algorithmId)).willReturn(Optional.empty());
+    // algorithmRepository에서 save 메서드를 호출하면 newAlgorithm 객체를 반환
+    given(algorithmRepository.save(any(Algorithm.class))).willReturn(newAlgorithm);
 
-        // when
-        Algorithm result = algorithmService.getOrCreateAlgorithm(algorithmId, koreanName, englishName);
+    // when
+    Algorithm result = algorithmService.getOrCreateAlgorithm(algorithmId, koreanName, englishName);
 
-        // then
-        assertThat(result).isEqualTo(newAlgorithm);
-        verify(algorithmRepository).save(any(Algorithm.class)); // save가 호출됨
-    }
+    // then
+    assertThat(result).isEqualTo(newAlgorithm);
+    verify(algorithmRepository).save(any(Algorithm.class)); // save가 호출됨
+  }
 
+  // [getAlgorithms] 정상 케이스 테스트
+  @Test
+  void getAlgorithmsNormalCase() {
+    // given
+    Algorithm algorithm1 =
+        Algorithm.builder().algorithmId(1).koreanName("정렬").englishName("Sort").build();
 
+    Algorithm algorithm2 =
+        Algorithm.builder().algorithmId(2).koreanName("그래프").englishName("Graph").build();
 
-    //[getAlgorithms] 정상 케이스 테스트
-    @Test
-    void getAlgorithms_normalCase() {
-        // given
-        Algorithm algorithm1 = Algorithm.builder()
-            .algorithmId(1)
-            .koreanName("정렬")
-            .englishName("Sort")
-            .build();
-            
-        Algorithm algorithm2 = Algorithm.builder()
-            .algorithmId(2)
-            .koreanName("그래프")
-            .englishName("Graph")
-            .build();
-            
-        List<Algorithm> algorithms = List.of(algorithm1, algorithm2);
-        given(algorithmRepository.findAll()).willReturn(algorithms);
+    List<Algorithm> algorithms = List.of(algorithm1, algorithm2);
+    given(algorithmRepository.findAll()).willReturn(algorithms);
 
-        // when
-        List<AlgorithmResponseDto> result = algorithmService.getAlgorithms();
+    // when
+    List<AlgorithmResponseDto> result = algorithmService.getAlgorithms();
 
-        // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getAlgorithmId()).isEqualTo(1);
-        assertThat(result.get(0).getName()).isEqualTo("정렬");
-        assertThat(result.get(1).getAlgorithmId()).isEqualTo(2);
-        assertThat(result.get(1).getName()).isEqualTo("그래프");
-        verify(algorithmRepository).findAll();
-    }
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getAlgorithmId()).isEqualTo(1);
+    assertThat(result.get(0).getName()).isEqualTo("정렬");
+    assertThat(result.get(1).getAlgorithmId()).isEqualTo(2);
+    assertThat(result.get(1).getName()).isEqualTo("그래프");
+    verify(algorithmRepository).findAll();
+  }
 
-    //[getAlgorithms] 빈 목록 케이스 테스트
-    @Test
-    void getAlgorithms_emptyList() {
-        // given
-        //algorithmRepository에서 findAll 메서드를 호출하면 빈 리스트를 반환
-        given(algorithmRepository.findAll()).willReturn(List.of());
+  // [getAlgorithms] 빈 목록 케이스 테스트
+  @Test
+  void getAlgorithmsEmptyList() {
+    // given
+    // algorithmRepository에서 findAll 메서드를 호출하면 빈 리스트를 반환
+    given(algorithmRepository.findAll()).willReturn(List.of());
 
-        // when
-        //getAlgorithms 메서드를 호출하고 반환된 객체를 List<AlgorithmResponseDto> result에 저장
-        List<AlgorithmResponseDto> result = algorithmService.getAlgorithms();
+    // when
+    // getAlgorithms 메서드를 호출하고 반환된 객체를 List<AlgorithmResponseDto> result에 저장
+    List<AlgorithmResponseDto> result = algorithmService.getAlgorithms();
 
-        // then
-        //result가 빈 리스트인지 확인
-        assertThat(result).isEmpty();
-        verify(algorithmRepository).findAll();
-    }
-
+    // then
+    // result가 빈 리스트인지 확인
+    assertThat(result).isEmpty();
+    verify(algorithmRepository).findAll();
+  }
 }

--- a/src/test/java/com/aloc/aloc/algorithm/service/AlgorithmServiceTest.java
+++ b/src/test/java/com/aloc/aloc/algorithm/service/AlgorithmServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import com.aloc.aloc.algorithm.dto.response.AlgorithmResponseDto;
 import com.aloc.aloc.algorithm.entity.Algorithm;
 import com.aloc.aloc.algorithm.repository.AlgorithmRepository;
 
@@ -19,6 +20,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.any;
+
+
+//테스트 함수 목록
+//[getAlgorithmsByIds] 메서드 테스트
+//[getAlgorithmsByIds] 없는 알고리즘 아이디 조회 테스트
+//[getOrCreateAlgorithm] 기존 알고리즘 조회 테스트
+//[getOrCreateAlgorithm] 새 알고리즘 생성 테스트
+//[getAlgorithms] 정상 케이스 테스트
+//[getAlgorithms] 빈 목록 케이스 테스트
 
 @ExtendWith(MockitoExtension.class)
 public class AlgorithmServiceTest {
@@ -33,7 +43,7 @@ public class AlgorithmServiceTest {
 
     //[getAlgorithmsByIds] 메서드 테스트
     @Test
-    void getAlgorithmsByIds() {
+    void getAlgorithmsByIds_normalCase() {
         //given
         //id 1인 객체를 생성
         Integer algorithmId = 1;
@@ -97,7 +107,7 @@ public class AlgorithmServiceTest {
 
     //[getOrCreateAlgorithm] 새 알고리즘 생성 테스트
     @Test
-    void getOrCreateAlgorithm_새_알고리즘_생성() {
+    void getOrCreateAlgorithm_newAlgorithm() {
         // given
         Integer algorithmId = 2;
         String koreanName = "그래프";
@@ -121,6 +131,56 @@ public class AlgorithmServiceTest {
         // then
         assertThat(result).isEqualTo(newAlgorithm);
         verify(algorithmRepository).save(any(Algorithm.class)); // save가 호출됨
+    }
+
+
+
+    //[getAlgorithms] 정상 케이스 테스트
+    @Test
+    void getAlgorithms_normalCase() {
+        // given
+        Algorithm algorithm1 = Algorithm.builder()
+            .algorithmId(1)
+            .koreanName("정렬")
+            .englishName("Sort")
+            .build();
+            
+        Algorithm algorithm2 = Algorithm.builder()
+            .algorithmId(2)
+            .koreanName("그래프")
+            .englishName("Graph")
+            .build();
+            
+        List<Algorithm> algorithms = List.of(algorithm1, algorithm2);
+        given(algorithmRepository.findAll()).willReturn(algorithms);
+
+        // when
+        List<AlgorithmResponseDto> result = algorithmService.getAlgorithms();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getAlgorithmId()).isEqualTo(1);
+        assertThat(result.get(0).getName()).isEqualTo("정렬");
+        assertThat(result.get(1).getAlgorithmId()).isEqualTo(2);
+        assertThat(result.get(1).getName()).isEqualTo("그래프");
+        verify(algorithmRepository).findAll();
+    }
+
+    //[getAlgorithms] 빈 목록 케이스 테스트
+    @Test
+    void getAlgorithms_emptyList() {
+        // given
+        //algorithmRepository에서 findAll 메서드를 호출하면 빈 리스트를 반환
+        given(algorithmRepository.findAll()).willReturn(List.of());
+
+        // when
+        //getAlgorithms 메서드를 호출하고 반환된 객체를 List<AlgorithmResponseDto> result에 저장
+        List<AlgorithmResponseDto> result = algorithmService.getAlgorithms();
+
+        // then
+        //result가 빈 리스트인지 확인
+        assertThat(result).isEmpty();
+        verify(algorithmRepository).findAll();
     }
 
 }

--- a/src/test/java/com/aloc/aloc/algorithm/service/AlgorithmServiceTest.java
+++ b/src/test/java/com/aloc/aloc/algorithm/service/AlgorithmServiceTest.java
@@ -16,6 +16,9 @@ import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.any;
 
 @ExtendWith(MockitoExtension.class)
 public class AlgorithmServiceTest {
@@ -66,5 +69,58 @@ public class AlgorithmServiceTest {
             .hasMessageContaining("존재하지 않은 알고리즘 아이디가 포함되어 있습니다.");
     }
 
+    //[getOrCreateAlgorithm] 기존 알고리즘 조회 테스트
+    @Test
+    void getOrCreateAlgorithm_existingAlgorithm() {
+        // given
+        Integer algorithmId = 1;
+        String koreanName = "정렬";
+        String englishName = "Sort";
+        
+        Algorithm existingAlgorithm = Algorithm.builder()
+            .algorithmId(algorithmId)
+            .koreanName("기존 한글명")
+            .englishName("Existing English Name")
+            .build();
+        
+        given(algorithmRepository.findByAlgorithmId(algorithmId))
+            .willReturn(Optional.of(existingAlgorithm));
+
+        // when
+        Algorithm result = algorithmService.getOrCreateAlgorithm(algorithmId, koreanName, englishName);
+
+        // then
+        assertThat(result).isEqualTo(existingAlgorithm);
+        verify(algorithmRepository, never()).save(any(Algorithm.class)); // save는 호출되지 않음
+    }
+
+
+    //[getOrCreateAlgorithm] 새 알고리즘 생성 테스트
+    @Test
+    void getOrCreateAlgorithm_새_알고리즘_생성() {
+        // given
+        Integer algorithmId = 2;
+        String koreanName = "그래프";
+        String englishName = "Graph";
+        
+        Algorithm newAlgorithm = Algorithm.builder()
+            .algorithmId(algorithmId)
+            .koreanName(koreanName)
+            .englishName(englishName)
+            .build();
+        //algorithmRepository에서 algorithmId 2인 객체를 조회하면 Optional.empty()를 반환
+        given(algorithmRepository.findByAlgorithmId(algorithmId))
+            .willReturn(Optional.empty());
+        //algorithmRepository에서 save 메서드를 호출하면 newAlgorithm 객체를 반환
+        given(algorithmRepository.save(any(Algorithm.class)))
+            .willReturn(newAlgorithm);
+
+        // when
+        Algorithm result = algorithmService.getOrCreateAlgorithm(algorithmId, koreanName, englishName);
+
+        // then
+        assertThat(result).isEqualTo(newAlgorithm);
+        verify(algorithmRepository).save(any(Algorithm.class)); // save가 호출됨
+    }
 
 }

--- a/src/test/java/com/aloc/aloc/algorithm/service/AlgorithmServiceTest.java
+++ b/src/test/java/com/aloc/aloc/algorithm/service/AlgorithmServiceTest.java
@@ -12,8 +12,10 @@ import com.aloc.aloc.algorithm.repository.AlgorithmRepository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(MockitoExtension.class)
 public class AlgorithmServiceTest {
@@ -26,6 +28,7 @@ public class AlgorithmServiceTest {
     @InjectMocks
     private AlgorithmService algorithmService;
 
+    //[getAlgorithmsByIds] 메서드 테스트
     @Test
     void getAlgorithmsByIds() {
         //given
@@ -47,4 +50,21 @@ public class AlgorithmServiceTest {
         //result의 크기가 1이고, 첫 번째 요소의 algorithmId가 1인지 확인
         assertThat(result).containsExactly(algorithm);
     }
-}   
+
+    //[getAlgorithmById] 없는 알고리즘 아이디 조회 테스트
+    @Test
+    void getAlgorithmsById_NotFound() {
+        //given
+        //mock에서는 존재하지 않는 아이디를 조회하면 Optional.empty()를 반환
+        Integer nonExistentId = 999;
+        given(algorithmRepository.findByAlgorithmId(nonExistentId)).willReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> algorithmService.getAlgorithmsByIds(List.of(nonExistentId)))
+            //NoSuchElementException 예외가 발생하고, 메시지에 "존재하지 않은 알고리즘 아이디가 포함되어 있습니다."가 포함되어 있는지 확인
+            .isInstanceOf(NoSuchElementException.class)
+            .hasMessageContaining("존재하지 않은 알고리즘 아이디가 포함되어 있습니다.");
+    }
+
+
+}

--- a/src/test/java/com/aloc/aloc/algorithm/service/AlgorithmServiceTest.java
+++ b/src/test/java/com/aloc/aloc/algorithm/service/AlgorithmServiceTest.java
@@ -1,0 +1,50 @@
+package com.aloc.aloc.algorithm.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.aloc.aloc.algorithm.entity.Algorithm;
+import com.aloc.aloc.algorithm.repository.AlgorithmRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+@ExtendWith(MockitoExtension.class)
+public class AlgorithmServiceTest {
+
+    // Algorithm Repository를 모방한 가짜 객체 만들기
+    @Mock
+    private AlgorithmRepository algorithmRepository;
+
+    // 가짜 객체를 사용하는 AlgorithmService 객체 만들기
+    @InjectMocks
+    private AlgorithmService algorithmService;
+
+    @Test
+    void getAlgorithmsByIds() {
+        //given
+        //id 1인 객체를 생성
+        Integer algorithmId = 1;
+        Algorithm algorithm = Algorithm.builder()
+            .algorithmId(algorithmId)
+            .koreanName("테스트")
+            .englishName("test")
+            .build();
+        //algorithmRepository에서 algorithmId 1인 객체를 조회하면 algorithm 객체를 반환
+        given(algorithmRepository.findByAlgorithmId(algorithmId)).willReturn(Optional.of(algorithm));
+    
+        //when
+        //algorithmId를 List.of(algorithmId)로 넘겨서 조회하고 반환된 객체를 List<Algorithm> result에 저장
+        List<Algorithm> result = algorithmService.getAlgorithmsByIds(List.of(algorithmId));
+
+        //then
+        //result의 크기가 1이고, 첫 번째 요소의 algorithmId가 1인지 확인
+        assertThat(result).containsExactly(algorithm);
+    }
+}   


### PR DESCRIPTION
feat: Algorithm 도메인 테스트 코드 작성
**작업내용**
AlgorithmService의 모든 public 메서드에 대한 단위 테스트 코드를 작성했습니다.
getAlgorithmsByIds, getOrCreateAlgorithm, getAlgorithms 메서드의 정상/예외 케이스를 포함한 총 6개의 테스트 케이스를 구현했습니다.
Mockito를 활용하여 Repository 의존성을 격리하고, given-when-then 패턴으로 테스트를 구조화했습니다.

**구현된 테스트 케이스**
getAlgorithmsByIds 정상 케이스 및 존재하지 않는 ID 예외 처리
getOrCreateAlgorithm 기존 알고리즘 조회 및 신규 알고리즘 생성
getAlgorithms 정상 조회 및 빈 목록 처리

**추가된 테스트 함수 목록**
// [getAlgorithmsByIds] 메서드 테스트
// [getAlgorithmsByIds] 없는 알고리즘 아이디 조회 테스트
// [getOrCreateAlgorithm] 기존 알고리즘 조회 테스트
// [getOrCreateAlgorithm] 새 알고리즘 생성 테스트
// [getAlgorithms] 정상 케이스 테스트
// [getAlgorithms] 빈 목록 케이스 테스트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * AlgorithmService에 대한 단위 테스트가 추가되었습니다. 다양한 시나리오(정상 조회, 존재하지 않는 ID, 신규 생성, 전체 조회 등)를 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->